### PR TITLE
fix: warnings module import error

### DIFF
--- a/syncrclone/main.py
+++ b/syncrclone/main.py
@@ -360,7 +360,7 @@ class SyncRClone:
                 mA,mB = sA,sB # Reset m(AB) to s(AB)
             
             if not mA or not mB: # Either never set for non-mtime compare or no mtime listed
-                warning.warn('No mtime found. Resorting to size')
+                warnings.warn('No mtime found. Resorting to size')
                 mA,mB = sA,sB # Reset m(AB) to s(AB)
                 
             log(f"CONFLICT '{path}'")


### PR DESCRIPTION
I'm still in my first hour using this tool, but so far it's working great and just the thing I was looking for. One minor hiccup I encountered was an import error when the library tried to raise a warning. It was an easy fix and I figured you'd appreciate the heads-up / PR. Cheers!