### PR TITLE
Customize tempfile base directory for syncrclone

### DIFF
--- a/syncrclone/cli.py
+++ b/syncrclone/cli.py
@@ -292,7 +292,7 @@ def cli(argv=None):
         if _RETURN:
             return r
     except Exception as E:
-        import tempfile
+        from . import tempfile
         
         tmpdir = tempfile.TemporaryDirectory().name
         os.makedirs(tmpdir)

--- a/syncrclone/main.py
+++ b/syncrclone/main.py
@@ -3,7 +3,6 @@ import json
 import time
 import sys,os,shutil
 import warnings
-import tempfile
 
 from . import debug,log
 from . import utils

--- a/syncrclone/rclone.py
+++ b/syncrclone/rclone.py
@@ -6,7 +6,6 @@ import os
 from collections import deque,defaultdict
 import subprocess,shlex
 import lzma
-import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor
 
@@ -14,6 +13,7 @@ from . import debug,log
 from .cli import ConfigError
 from .dicttable import DictTable
 from . import utils
+from . import tempfile
 
 FILTER_FLAGS = {'--include', '--exclude', '--include-from', '--exclude-from', 
                 '--filter', '--filter-from','--files-from'}

--- a/syncrclone/tempfile.py
+++ b/syncrclone/tempfile.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+"""
+Setting a custom path for tempfile
+"""
+
+import os
+import sys
+import tempfile
+
+tempfile.tempdir = os.path.join(tempfile.gettempdir(), 'syncrclone')
+if not os.path.exists(tempfile.tempdir):
+    os.makedirs(tempfile.tempdir)
+
+sys.modules[__name__] = tempfile

--- a/utils/rclone-dated-delete
+++ b/utils/rclone-dated-delete
@@ -11,7 +11,6 @@ Additional arguments are passed to rclone
 """
 import time
 from datetime import datetime
-import tempfile
 import subprocess
 import shlex
 import operator
@@ -21,6 +20,8 @@ import re
 import sys,os
 from concurrent.futures import ThreadPoolExecutor
 import argparse
+
+from . import tempfile
 
 __version__ = '20211101.0'
 


### PR DESCRIPTION
* syncrclone/tempfile.py: Patch monkey the library to use the
`syncrclone` directory.
* syncrclone/rclone.py: Import the patched library.
* utils/rclone-dated-delete: Import the patched library.
* syncrclone/main.py: Remove unused import.