### PR TITLE
Customize tempfile base directory for syncrclone

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 This will likely get wiped when I go out of beta. 
 
+## 20220219.0.BETA
+
+* Add the option to set the temporary directory suffix used. This enables using a specified directory in the system temporary directory. Before, all files using the temporary directory had the form (on linux) of `/tmp/tmp[8 characters]`. Now they can have this form: `/tmp/[syncrclone]/tmp[8 characters]`.
+
 ## 20220204.0.BETA
 
 Minor fixes and improvements.

--- a/syncrclone/cli.py
+++ b/syncrclone/cli.py
@@ -294,8 +294,10 @@ def cli(argv=None):
     except Exception as E:
         import tempfile
         
+        tempfile.tempdir = os.path.join(tempfile.gettempdir(), config.tmp_dir_suffix)
+        if not os.path.exists(tempfile.gettempdir()):
+            os.makedirs(tempfile.gettempdir())
         tmpdir = tempfile.TemporaryDirectory().name
-        os.makedirs(tmpdir)
         print(f"ERROR. Dumping logs (with debug) to '{tmpdir}/log.txt'",file=sys.stderr)
         with open(f'{tmpdir}/log.txt','wt') as fout:
             fout.write(''.join(line for _,line in log.hist))

--- a/syncrclone/config_example.py
+++ b/syncrclone/config_example.py
@@ -220,6 +220,10 @@ renamesB = None
 save_logs = True
 local_log_dest = '' # NOT on a remote
 
+# This is the suffix appended to the operating system temporary
+# folder.  This would mean /tmp/[suffix_directory]/ on most unices
+tmp_dir_suffix = 'synrclone'
+
 ## Pre- and Post-run
 # Specify shell code to be evaluated before and/or after running syncrclone. Note
 # these are all run from the directory of this config (as with everything else).

--- a/syncrclone/main.py
+++ b/syncrclone/main.py
@@ -3,7 +3,6 @@ import json
 import time
 import sys,os,shutil
 import warnings
-import tempfile
 
 from . import debug,log
 from . import utils

--- a/syncrclone/rclone.py
+++ b/syncrclone/rclone.py
@@ -33,14 +33,13 @@ class Rclone:
     def __init__(self,config):
         self.config = config
         self.add_args = [] # logging, etc
+        
+        tempfile.tempdir = os.path.join(tempfile.gettempdir(), self.config.tmp_dir_suffix)
+        if not os.path.exists(tempfile.gettempdir()):
+            os.makedirs(tempfile.gettempdir())
         self.tmpdir = tempfile.TemporaryDirectory().name
         
         self.rclonetime = 0.0
-        
-        try:
-            os.makedirs(self.tmpdir)
-        except OSError:
-            pass
         
         self.validate()
         

--- a/utils/rclone-dated-delete
+++ b/utils/rclone-dated-delete
@@ -61,6 +61,9 @@ parser.add_argument('pattern',
           'which is the date. It may not always work. Use `--dry-run` to see what will be deleted and `--dry-run -vv`'
           'to see all matches'))
 
+parser.add_argument('--tmp-dir-suffix',default='rclone',
+    help=('[%(default)s] temporary suffix directory. By default the tmp directory might be /tmp/%(default)s. Depending on the system, the preceding path might be different'))
+
 parser.add_argument('--version', action='version', 
     version='%(prog)s-' + __version__)
     
@@ -179,6 +182,10 @@ if delfiles:
     # Delete can be done with a single call using `--files-from`
     if args.verbose:
         print('Deleting Files')
+    
+    tempfile.tempdir = os.path.join(tempfile.gettempdir(), args.tmp_dir_suffix)
+    if not os.path.exists(tempfile.gettempdir()):
+        os.makedirs(tempfile.gettempdir())
     with tempfile.NamedTemporaryFile(mode='wt',delete=False) as delist:
         delist.write('\n'.join(delfiles))
 


### PR DESCRIPTION
* syncrclone/rclone.py (Rclone.__init__): Customize the `tempfile.tempdir` to
use the new config. Create the directory if it doesn’t exist.
* syncrclone/cli.py (cli): Same as above. Also remove a line that is redundant.
* syncrclone/config_example.py: Add a new configuration option to set the
temporary directory suffix. By default: `synrclone`.
* utils/rclone-dated-delete: Add parser option for tmp-dir-suffix.  Also had the
ability to change the default temporary directory suffix.
* docs/changelog.md: Update changes about this new feature.

One thing to note: when calling `tempfile.TemporaryDirectory()`, it automatically create the directory.  There's no need to call `os.makedirs`.