### PR TITLE
#22 Check if file exists before decompressing

### DIFF
--- a/syncrclone/rclone.py
+++ b/syncrclone/rclone.py
@@ -174,6 +174,9 @@ class Rclone:
                 log(f'No previous list on {AB}. Reset state')
                 return [] 
         
+        if not os.path.isfile(dst):
+            return []
+
         with lzma.open(dst) as file:
             return json.load(file)
 


### PR DESCRIPTION
Happens on initial run when .syncrclone does not exist in either local or remote (at least when using s3 as B)

I think I got a handle on what the situation was:

I think this is happening b/c the command below was succeeding but not actually copying anything down (because there is notthing upstream). Since it didn't error, the `catch` never got triggered but also `dst` does not exist on disk

```
rclone --retries 1 copyto s3-backup:kswann-test-sync-bucket/.syncrclone/B-sdlvS_fl.json.xz /tmp/tmpfsc2g_w1/B_prev 
```

Feel free to modify this PR as you see fit!